### PR TITLE
docs: update tech stack from TypeORM to @stingerloom/orm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is the blog server that is made with the server framework called ne
 In this directory named `backend` will finish off the features of our server by adding a lot of controllers, services, pipes of `Nest.js` for blog service.
 
 - Nest.js
-- TypeORM
+- @stingerloom/orm
 - MariaDB
 - Redis
 


### PR DESCRIPTION
루트 README 의 기술 스택 목록을 `TypeORM` → `@stingerloom/orm` 으로 갱신합니다. (PR #42 로 TypeORM 의존성이 제거되어 더 이상 사용하지 않음)